### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/skosa786/7de949ee-b8b5-4cd4-a00f-7609675426b3/38458171-9324-489f-b886-ac9e0f9965a3/_apis/work/boardbadge/866cb1f7-4d91-4c06-a3a6-d1f7a90ce8e1)](https://dev.azure.com/skosa786/7de949ee-b8b5-4cd4-a00f-7609675426b3/_boards/board/t/38458171-9324-489f-b886-ac9e0f9965a3/Microsoft.RequirementCategory)
 # hello-osama
 Owning our story and loving ourselves through that process is the bravest thing that we’ll ever do.
 Never be bullied into silence. Never allow yourself to be made a victim. Accept no one’s definition of your life, but define yourself.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/skosa786/7de949ee-b8b5-4cd4-a00f-7609675426b3/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.